### PR TITLE
PR1: Add dummy Dockerfile with long-running http.server

### DIFF
--- a/app-ml/Dockerfile
+++ b/app-ml/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.10-slim
+
+WORKDIR /app
+
+EXPOSE 8000
+
+CMD ["python", "-m", "http.server", "8000"]


### PR DESCRIPTION
- Created a minimal Dockerfile in `app-ml/` using `python -m http.server`
- Built and tested locally
- Image pushed to Docker Hub: https://hub.docker.com/r/katerynakomissarova/app-ml
