### PR TITLE
PR3: Add Kubernetes YAML definitions for Pod, Deployment, Service, and Job

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,22 @@
+name: Docker CI/CD
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Log in to Docker Hub
+        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+
+      - name: Build Docker image
+        run: docker build -t ${{ secrets.DOCKER_USERNAME }}/app-ml:${{ github.sha }} ./app-ml
+
+      - name: Push Docker image
+        run: docker push ${{ secrets.DOCKER_USERNAME }}/app-ml:${{ github.sha }}

--- a/app-ml/Dockerfile
+++ b/app-ml/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.10-slim
+
+WORKDIR /app
+
+EXPOSE 8000
+
+CMD ["python", "-m", "http.server", "8000"]

--- a/k8s-resources/deployment.yaml
+++ b/k8s-resources/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app-ml-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app-ml
+  template:
+    metadata:
+      labels:
+        app: app-ml
+    spec:
+      containers:
+        - name: app-ml-container
+          image: katerynakomissarova/app-ml:latest
+          ports:
+            - containerPort: 8000

--- a/k8s-resources/job.yaml
+++ b/k8s-resources/job.yaml
@@ -1,0 +1,13 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: app-ml-job
+spec:
+  template:
+    spec:
+      containers:
+        - name: app-ml-container
+          image: katerynakomissarova/app-ml:latest
+          command: ["python", "-m", "http.server", "8000"]
+      restartPolicy: Never
+  backoffLimit: 2

--- a/k8s-resources/pod.yaml
+++ b/k8s-resources/pod.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: app-ml-pod
+spec:
+  containers:
+    - name: app-ml-container
+      image: katerynakomissarova/app-ml:latest
+      ports:
+        - containerPort: 8000

--- a/k8s-resources/service.yaml
+++ b/k8s-resources/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: app-ml-service
+spec:
+  type: NodePort
+  selector:
+    app: app-ml
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000
+      nodePort: 30080
+


### PR DESCRIPTION
- Added all 4 Kubernetes YAML manifests: pod.yaml, deployment.yaml, service.yaml, job.yaml
- Using Docker image from Docker Hub: katerynakomissarova/app-ml:latest
- Tested locally with Minikube — all resources are created and service is accessible in browser