### PR TITLE
PR4: Add inference benchmarking with sequential and parallel execution

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -8,3 +8,26 @@ This project aims to provide a comprehensive guide and tools for deploying machi
    ```bash
    git clone https://github.com/Corsika1634/ML-in-production.git
    cd ML-in-production
+   ```
+
+---
+
+## 🧪 Inference Benchmark (PR4)
+
+This benchmark compares **sequential vs parallel inference performance** using a simulated `predict(x)` function  
+(each call sleeps for 10ms to emulate latency).
+
+The script is located at:
+```
+benchmark/benchmark_inference.py
+```
+
+### 🔍 Results (100 inference requests)
+
+| Mode        | Time (s)    |
+|-------------|-------------|
+| Sequential  | 1.2059      |
+| Parallel    | 0.5086      |
+
+**Speedup:** ~2.37× faster with multiprocessing
+

--- a/benchmark/benchmark_inference.py
+++ b/benchmark/benchmark_inference.py
@@ -1,0 +1,43 @@
+import time
+import multiprocessing as mp
+
+# Fake inference function
+def predict(x):
+    time.sleep(0.01)  # Simulate prediction time
+    return x * x
+
+# Sequential run
+def run_sequential(inputs):
+    results = []
+    for x in inputs:
+        results.append(predict(x))
+    return results
+
+# Parallel run
+def run_parallel(inputs):
+    with mp.Pool(mp.cpu_count()) as pool:
+        results = pool.map(predict, inputs)
+    return results
+
+def main():
+    inputs = list(range(100))  # 100 "requests" for inference
+
+    print("\nSequential inference...")
+    start = time.time()
+    run_sequential(inputs)
+    duration_seq = time.time() - start
+    print(f"Sequential execution time: {duration_seq:.4f} seconds")
+
+    print("\nParallel inference...")
+    start = time.time()
+    run_parallel(inputs)
+    duration_par = time.time() - start
+    print(f"Parallel execution time: {duration_par:.4f} seconds")
+
+    print("\nSummary:")
+    print(f"- Sequential: {duration_seq:.4f}s")
+    print(f"- Parallel: {duration_par:.4f}s")
+    print(f"- Speedup: {duration_seq / duration_par:.2f}x faster")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### PR4: Add Inference Benchmarking Script

**Summary:**
- Implemented `benchmark/benchmark_inference.py` to benchmark inference performance.
- Compared sequential execution (single process) and parallel execution (using multiprocessing).
- Measured total execution time for 100 inference operations and calculated speedup.

**How to test:**
- Activate the virtual environment.
- Run the benchmark script:

```bash
python benchmark/benchmark_inference.py
```

**Expected result:**
- Sequential execution time is printed.
- Parallel execution time is printed.
- Speedup factor (how much faster parallel is compared to sequential) is displayed.
