### PR TITLE
PR6: Add vectorization script with local ChromaDB storage and similarity query

### DIFF
--- a/benchmark/vector_db_example.py
+++ b/benchmark/vector_db_example.py
@@ -1,0 +1,43 @@
+from sentence_transformers import SentenceTransformer
+import chromadb
+from chromadb import PersistentClient
+
+def main():
+    # 1. Initialize embedding model
+    model = SentenceTransformer('all-MiniLM-L6-v2')
+
+    # 2. Sample text data
+    documents = ["cat", "dog", "horse", "tree", "car", "ocean", "mountain", "river", "city", "computer"]
+
+    # 3. Vectorize the text data
+    embeddings = model.encode(documents).tolist()
+
+    # 4. Initialize local VectorDB (Chroma)
+    client = PersistentClient(path="./vector_db")
+
+
+    collection = client.get_or_create_collection(name="example_collection")
+
+    # 5. Add documents and embeddings to the collection
+    collection.add(
+        documents=documents,
+        embeddings=embeddings,
+        ids=[str(i) for i in range(len(documents))]
+    )
+
+    # 6. Example query: find vectors similar to the query text
+    query = "laptop"
+    query_embedding = model.encode([query]).tolist()
+
+    results = collection.query(
+        query_embeddings=query_embedding,
+        n_results=3
+    )
+
+    print(f"\nQuery: {query}")
+    print("Top results:")
+    for doc in results['documents'][0]:
+        print(f"- {doc}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### PR6: Add Vectorization and VectorDB Storage Example

**Changes:**
- Added `benchmark/vector_db_example.py` script.
- Used `sentence-transformers` to vectorize a small set of texts.
- Saved embeddings into a local `ChromaDB` vector database.
- Implemented a similarity query to find documents close to a given query.

**How to test:**
- Install dependencies:

```bash
pip install sentence-transformers chromadb
```

- Run the script:

```bash
python benchmark/vector_db_example.py
```

- Verify that nearest documents are returned for the query.
